### PR TITLE
Support ele package in protobuf

### DIFF
--- a/mbuild/formats/compound.proto
+++ b/mbuild/formats/compound.proto
@@ -13,6 +13,13 @@ message Vec2 {
     int64 id2 = 2;
 }
 
+message Element {
+    string name = 1;
+    string symbol = 2;
+    int64 atomic_number = 3;
+    float mass = 4;
+}
+
 message Compound {
     string name = 1;
     repeated Compound children = 2;
@@ -21,6 +28,7 @@ message Compound {
     float charge = 5;
     int64 id = 6; // this is simply a unique number for this compound
     repeated Vec2 bonds = 7;  // a list of 2-tuples
+    Element element = 8;
 
     // Todo: Maybe need something for port particles
 }

--- a/mbuild/formats/protobuf.py
+++ b/mbuild/formats/protobuf.py
@@ -1,4 +1,5 @@
 import mbuild as mb
+import ele
 from mbuild.formats import compound_pb2
 from google.protobuf.text_format import PrintMessage, Merge
 
@@ -93,6 +94,11 @@ def _mb_to_proto(cmpd, proto):
     proto.charge = cmpd.charge
     proto.id = id(cmpd)
     proto.periodicity.x, proto.periodicity.y, proto.periodicity.z = cmpd.periodicity
+    if cmpd.element:
+        proto.element.name = cmpd.element.name
+        proto.element.symbol = cmpd.element.symbol
+        proto.element.atomic_number = cmpd.element.atomic_number
+        proto.element.mass  = cmpd.element.mass
    
     return proto
 
@@ -141,11 +147,16 @@ def _proto_to_mb(proto):
     proto: compound_pb2.Compound()
     
     """
+    if proto.element.symbol is '':
+        elem = None
+    else:
+        elem = ele.element_from_symbol(proto.element.symbol)
     return  mb.Compound(name=proto.name,
                 pos=[proto.pos.x, proto.pos.y, proto.pos.z],
                 charge=proto.charge,
                 periodicity=[proto.periodicity.x, proto.periodicity.y, 
-                            proto.periodicity.z])
+                            proto.periodicity.z],
+                element=elem)
 
 def _add_mb_bonds(proto, cmpd, proto_to_cmpd):
     """ Parse the compound_pb2.Compound bonds, add to mb.Compound


### PR DESCRIPTION
With the additional element support included thanks to the `ele`
package, the protobuf specification needs to be updated.

Currently, the entire element is represented using a protobuf Message.
Although when reading in from a protobuf'd compound, the element symbol
is used to generate a `ele` Element.

### PR Summary:

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
