### PR TITLE
Support json serialization of elements

### DIFF
--- a/mbuild/formats/json_formats.py
+++ b/mbuild/formats/json_formats.py
@@ -164,7 +164,7 @@ def _dict_to_mb(compound_dict):
     elif isinstance(element, list):
         atom_num = element[0]
         element = ele.element_from_atomic_number(atom_num)
-    elif isinstance(element,str):
+    elif isinstance(element, str):
         pass
     else:
         pass

--- a/mbuild/formats/json_formats.py
+++ b/mbuild/formats/json_formats.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 
 import mbuild as mb
 from mbuild.exceptions import MBuildError
+import ele
 
 
 def compound_from_json(json_file):
@@ -124,6 +125,7 @@ def _particle_info(cmpd, include_ports=False):
     particle_dict['pos'] = list(cmpd.pos)
     particle_dict['charge'] = cmpd.charge
     particle_dict['periodicity'] = list(cmpd.periodicity)
+    particle_dict['element'] = cmpd.element
 
     if include_ports:
         particle_dict['ports'] = list()
@@ -156,7 +158,19 @@ def _dict_to_mb(compound_dict):
     pos = compound_dict.get('pos', [0.0, 0.0, 0.0])
     charge = compound_dict.get('charge', 0.0)
     periodicity = compound_dict.get('periodicity', [0.0, 0.0, 0.0])
-    this_particle = mb.Compound(name=name, pos=pos, charge=charge, periodicity=periodicity)
+    element = compound_dict.get('element', None)
+    if isinstance(element, ele.element.Element):
+        pass
+    elif isinstance(element, list):
+        atom_num = element[0]
+        element = ele.element_from_atomic_number(atom_num)
+    elif isinstance(element,str):
+        pass
+    else:
+        pass
+
+    this_particle = mb.Compound(name=name, pos=pos, charge=charge,
+                                periodicity=periodicity, element=element)
     return this_particle
 
 

--- a/mbuild/tests/test_json_formats.py
+++ b/mbuild/tests/test_json_formats.py
@@ -6,8 +6,12 @@ import mbuild as mb
 class TestJSONFormats(BaseTest):
 
     def test_loop(self, ethane):
+        for part in ethane:
+            part.element = part.name
         compound_to_json(ethane, 'ethane.json')
         ethane_copy = compound_from_json('ethane.json')
+        for part_orig, part_copy in zip(ethane, ethane_copy):
+            assert part_orig.element.symbol == part_copy.element.symbol
         assert ethane.n_particles == ethane_copy.n_particles
         assert ethane.n_bonds == ethane_copy.n_bonds
         assert len(ethane.children) == len(ethane_copy.children)
@@ -72,5 +76,3 @@ class TestJSONFormats(BaseTest):
         for child, child_copy in zip(parent.successors(), parent_copy.successors()):
             assert child.labels.keys() == child_copy.labels.keys()
         assert parent_copy.available_ports() == parent.available_ports()
-
-


### PR DESCRIPTION
With the addition of the mb.Compound.element attribute, the various supported formats for reading/writing to mb.Compounds needed to be updated.

This commit includes support for elements (ele.element or a string
representation) when being serialized or de-serialized to/from the JSON
format.
The relevant unit tests were also updated.

### PR Summary:

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
